### PR TITLE
Remove legacy STT parameter normalization hook

### DIFF
--- a/Core/InfernConfig.py
+++ b/Core/InfernConfig.py
@@ -5,6 +5,7 @@ from Cluster.InfernSIPActor import InfernSIPActor
 from SIP.InfernSIPConf import InfernSIPConf
 from SIP.InfernSIPProfile import InfernSIPProfile
 from RTP.InfernRTPConf import InfernRTPConf
+from Models.InfernModelConf import InfernModelConf
 
 from .ConfigValidators import validate_yaml
 
@@ -23,6 +24,12 @@ schema = {
             **InfernRTPConf.schema,
         }
     },
+    'models': {
+        'type': 'dict',
+        'schema': {
+            **InfernModelConf.schema,
+        }
+    },
     'apps': {
         'type': 'dict',
         'schema': {
@@ -36,6 +43,7 @@ class InfernConfig():
     sip_conf: Optional[InfernSIPConf]
     rtp_conf: Optional[InfernRTPConf]
     connectors: Dict[str, InfernSIPProfile]
+    model_conf: Optional[InfernModelConf]
     apps: Dict[str, Union['LTProfile', 'AIAProfile']]
     def __init__(self, filename: str):
         from Apps.LiveTranslator.LTProfile import LTProfile
@@ -47,6 +55,7 @@ class InfernConfig():
         d = validate_yaml(schema, filename)
         self.sip_conf = InfernSIPConf(d['sip'].get('settings', None)) if 'sip' in d else None
         self.rtp_conf = InfernRTPConf(d['rtp'].get('settings', None)) if 'rtp' in d else None
+        self.model_conf = InfernModelConf(d.get('models'))
         try:
             self.connectors = dict((f'sip/{name}', InfernSIPProfile(name, conf))
                                 for name, conf in d['sip']['profiles'].items())

--- a/Models/InfernModelConf.py
+++ b/Models/InfernModelConf.py
@@ -1,5 +1,7 @@
-from typing import Optional
+from typing import Dict, Optional
 from os.path import expanduser
+
+from .InfernModelProfile import InfernModelProfile
 
 class InfernModelConf():
     schema: dict = {
@@ -14,14 +16,20 @@ class InfernModelConf():
             'keysrules': {'type': 'string'},
             'valuesrules': {
                 'type': 'dict',
-                'schema': {
-                    'uses': {'type': 'string'},
-                }
+                'schema': InfernModelProfile.schema,
             }
         }
     }
     cache_dir: str = '~/.cache/Infernos'
+    profiles: Dict[str, InfernModelProfile]
 
-    def __init__(self, conf:Optional[dict]=None):
-        cdir = conf['cache_dir'] if conf is not None and 'cache_dir' in conf else self.cache_dir
+    def __init__(self, conf: Optional[dict] = None):
+        conf = conf or {}
+        settings = conf.get('settings') or {}
+        cdir = settings.get('cache_dir', self.cache_dir)
         self.cache_dir = expanduser(cdir)
+        profiles_conf = conf.get('profiles') or {}
+        self.profiles = {
+            name: InfernModelProfile(name, profile_conf)
+            for name, profile_conf in profiles_conf.items()
+        }

--- a/Models/InfernModelProfile.py
+++ b/Models/InfernModelProfile.py
@@ -1,21 +1,42 @@
-from typing import Optional, Tuple
-from functools import partial
+from typing import Dict, Optional
 
 from .STT.Whisper import Whisper
 from .STT.WhisperRT import WhisperRT
+
+from cerberus import Validator
+
+from Core.ConfigValidators import InfernConfigParseErr
 
 stt_models = {m.provides: m for m in (Whisper, WhisperRT)}
 
 class InfernModelProfile():
     schema: dict = {
-        'uses': { 'type': 'string' },
+        'uses': {'type': 'string', 'required': True},
         'batch_size': {'type': 'integer', 'min': 1, 'max': 65535},
+        'parameters': {
+            'type': 'dict',
+            'default_setter': lambda _: {},
+            'allow_unknown': True,
+        },
     }
 
-    @staticmethod
-    def getSchemaImpl(uses):
-        if uses not in stt_models:
-            raise ValueError(f'Unknown STT model "{uses}"')
-        schema = stt_models[uses].schema.copy()
-        schema.update(InfernModelProfile.schema)
-        return schema
+    name: str
+    uses: str
+    batch_size: Optional[int]
+    parameters: Dict[str, object]
+    model_cls: type
+
+    def __init__(self, name: str, conf: dict):
+        self.name = name
+        self.uses = conf['uses']
+        if self.uses not in stt_models:
+            raise InfernConfigParseErr(f'Unknown STT model "{self.uses}" for profile "{name}"')
+        self.model_cls = stt_models[self.uses]
+        params = dict(conf.get('parameters') or {})
+        validator = Validator(self.model_cls.schema, allow_unknown=False)
+        if not validator.validate(params):
+            raise InfernConfigParseErr(
+                f'Invalid parameters for STT model profile "{name}" ({self.uses}): {validator.errors}'
+            )
+        self.parameters = validator.document
+        self.batch_size = conf.get('batch_size')

--- a/Models/STT/Whisper.py
+++ b/Models/STT/Whisper.py
@@ -15,7 +15,15 @@ from Cluster.InfernBatchedWorker import InfernBatchedWorker
 
 class Whisper(InfernBatchedWorker):
     provides: str = "whisper"
-    schema: dict = {}
+    schema: dict = {
+        'device': {
+            'type': 'string',
+            'allowed': ['cpu', 'cuda', 'xpu'],
+        },
+        'model_name': {
+            'type': 'string',
+        },
+    }
     max_batch_size: int = 4
     max_chunk_duration: float = 32.0
     model: ctranslate2.models.Whisper

--- a/Models/STT/WhisperRT.py
+++ b/Models/STT/WhisperRT.py
@@ -17,7 +17,27 @@ class WhisperRT(InfernBatchedWorker):
     """Inference worker that runs Whisper via faster-whisper on CUDA."""
 
     provides: str = "whisper_rt"
-    schema: dict = {}
+    schema: dict = {
+        'device': {
+            'type': 'string',
+            'allowed': ['auto', 'cpu', 'cuda'],
+        },
+        'model_size': {
+            'type': 'string',
+        },
+        'compute_type': {
+            'type': 'string',
+            'allowed': ['int8', 'int8_float16', 'int8_float32', 'float16', 'float32'],
+        },
+        'beam_size': {
+            'type': 'integer',
+            'min': 1,
+            'coerce': int,
+        },
+        'cache_dir': {
+            'type': 'string',
+        },
+    }
     max_batch_size: int = 2
     max_chunk_duration: float = 24.0
     sample_rate: int = 16000


### PR DESCRIPTION
## Summary
- stop `InfernModelProfile` from invoking implementation-defined parameter normalizers
- drop the unused `normalize_parameters` helper from `WhisperRT`

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68dda83b79248322b5055a1aa769eca3